### PR TITLE
100% test coverage

### DIFF
--- a/test.js
+++ b/test.js
@@ -20,6 +20,7 @@ test('.get() - limit', t => {
 	lru.set('1', 1);
 	lru.set('2', 2);
 	t.is(lru.get('1'), 1);
+	t.is(lru.get('3'), undefined);
 	lru.set('3', 3);
 	lru.get('1');
 	lru.set('4', 4);
@@ -64,6 +65,7 @@ test('.peek()', t => {
 	t.is(lru.peek('1'), 1);
 	lru.set('2', 2);
 	t.is(lru.peek('1'), 1);
+	t.is(lru.peek('3'), undefined);
 	lru.set('3', 3);
 	lru.set('4', 4);
 	t.false(lru.has('1'));


### PR DESCRIPTION
After maxSize is reached, oldCache is reassigned. Try reading values that are in neither cache so the else-branch is hit, achieving 100% test coverage.

---

The [Coveralls output](https://coveralls.io/builds/10843922/source?filename=index.js#L30) is confusing, but it's clearer when you look at `nyc`'s HTML report (`"$(npm bin)"/nyc report --reporter=html`).