### PR TITLE
Fix docs: maxSize is a number, not an Object

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ Type: `Object`
 #### maxSize
 
 *Required*<br>
-Type: `Object`
+Type: `number`
 
 Maximum number of items before evicting the least recently used items.
 


### PR DESCRIPTION
While we're at it, thanks for the module. :)