### PR TITLE
Add entries method

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,6 +85,12 @@ class QuickLRU {
 		}
 	}
 
+	* entries() {
+		for (const [key, value] of this) {
+			yield [key, value];
+		}
+	}
+
 	* [Symbol.iterator]() {
 		for (const item of this.cache) {
 			yield item;


### PR DESCRIPTION
This cache is mentioned in [mem](https://github.com/sindresorhus/mem) which in turn uses [map-age-cleaner](https://github.com/SamVerschueren/map-age-cleaner).

The latter somehow relies on the `entries()` method.
Is it possible to add the method as suggested by this PR?