### PR TITLE
Fix `.size` not matching the `maxSize` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ class QuickLRU {
 			}
 		}
 
-		return this._size + oldCacheSize;
+		return Math.min(this._size + oldCacheSize, this.maxSize);
 	}
 }
 

--- a/test.js
+++ b/test.js
@@ -166,6 +166,15 @@ test('.size - accounts for duplicates', t => {
 	t.is(lru.size, 2);
 });
 
+test('max size', t => {
+	const lru = new QuickLRU({maxSize: 3});
+	lru.set('1', 1);
+	lru.set('2', 2);
+	lru.set('3', 3);
+	lru.set('4', 4);
+	t.is(lru.size, 3);
+});
+
 test('checks total cache size does not exceed `maxSize`', t => {
 	const lru = new QuickLRU({maxSize: 2});
 	lru.set('1', 1);
@@ -173,3 +182,4 @@ test('checks total cache size does not exceed `maxSize`', t => {
 	lru.get('1');
 	t.is(lru.oldCache.has('1'), false);
 });
+

--- a/test.js
+++ b/test.js
@@ -182,4 +182,3 @@ test('checks total cache size does not exceed `maxSize`', t => {
 	lru.get('1');
 	t.is(lru.oldCache.has('1'), false);
 });
-


### PR DESCRIPTION
The maximum length is not the length of the memory