### PR TITLE
Add `onEviction` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,11 +4,13 @@ declare namespace QuickLRU {
 		The maximum number of items before evicting the least recently used items.
 		*/
 		readonly maxSize: number;
+
 		/**
-		Called when an item will be evicted from the cache. 
-		Useful for side effects or for items like object URLs that need explicit cleanup (revokeObjectURL).
+		Called right before an item is evicted from the cache.
+
+		Useful for side effects or for items like object URLs that need explicit cleanup (`revokeObjectURL`).
 		*/
-		onEviction?: <KeyType, ValueType> (key: KeyType, value: ValueType) => void;
+		onEviction?: <KeyType, ValueType>(key: KeyType, value: ValueType) => void;
 	}
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,10 @@ declare namespace QuickLRU {
 		The maximum number of items before evicting the least recently used items.
 		*/
 		readonly maxSize: number;
+		/**
+	  Method to call when an item is about to be evicted from the cache. Useful when a cleanup operation is necessary.
+		*/
+		onEviction?: (key: any, value: any) => void;
 	}
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,9 +5,10 @@ declare namespace QuickLRU {
 		*/
 		readonly maxSize: number;
 		/**
-	  Method to call when an item is about to be evicted from the cache. Useful when a cleanup operation is necessary.
+		Called when an item will be evicted from the cache. 
+		Useful for side effects or for items like object URLs that need explicit cleanup (revokeObjectURL).
 		*/
-		onEviction?: (key: any, value: any) => void;
+		onEviction?: <KeyType, ValueType> (key: KeyType, value: ValueType) => void;
 	}
 }
 

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ class QuickLRU {
 		}
 
 		this.maxSize = options.maxSize;
+		this.onEviction = options.onEviction;
 		this.cache = new Map();
 		this.oldCache = new Map();
 		this._size = 0;
@@ -18,6 +19,13 @@ class QuickLRU {
 
 		if (this._size >= this.maxSize) {
 			this._size = 0;
+
+			if (typeof this.onEviction === 'function') {
+				for (const [key, value] of this.oldCache.entries()) {
+					this.onEviction(key, value);
+				}
+			}
+
 			this.oldCache = this.cache;
 			this.cache = new Map();
 		}

--- a/readme.md
+++ b/readme.md
@@ -46,10 +46,12 @@ Type: `number`
 The maximum number of items before evicting the least recently used items.
 
 #### onEviction
+
 *Optional*\
 Type: `(key, value) => void`
 
-Called when an item will be evicted from the cache. 
+Called right before an item is evicted from the cache.
+
 Useful for side effects or for items like object URLs that need explicit cleanup (`revokeObjectURL`).
 
 ### Instance

--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,12 @@ Type: `number`
 
 The maximum number of items before evicting the least recently used items.
 
+#### onEviction
+*Optional*\
+Type: `(key, value) => void`
+
+Method to call when an item is about to be evicted from the cache. Useful when a cleanup operation is necessary.
+
 ### Instance
 
 The instance is [`iterable`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Iteration_protocols) so you can use it directly in a [`for…of`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Statements/for...of) loop.

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,8 @@ The maximum number of items before evicting the least recently used items.
 *Optional*\
 Type: `(key, value) => void`
 
-Method to call when an item is about to be evicted from the cache. Useful when a cleanup operation is necessary.
+Called when an item will be evicted from the cache. 
+Useful for side effects or for items like object URLs that need explicit cleanup (`revokeObjectURL`).
 
 ### Instance
 

--- a/test.js
+++ b/test.js
@@ -183,22 +183,23 @@ test('checks total cache size does not exceed `maxSize`', t => {
 	t.is(lru.oldCache.has('1'), false);
 });
 
-test('checks to see if onEviction method is called after `maxSize` is exceeded', t => {
+test('`onEviction` option method is called after `maxSize` is exceeded', t => {
+	const expectKey = '1';
+	const expectValue = 1;
 	let isCalled = false;
 	let actualKey;
-	let actualVal;
-	const expectKey = '1';
-	const expectVal = 1;
-	const onEviction = (key, val) => {
+	let actualValue;
+
+	const onEviction = (key, value) => {
 		actualKey = key;
-		actualVal = val;
+		actualValue = value;
 		isCalled = true;
 	};
 
 	const lru = new QuickLRU({maxSize: 1, onEviction});
-	lru.set(expectKey, expectVal);
+	lru.set(expectKey, expectValue);
 	lru.set('2', 2);
 	t.is(actualKey, expectKey);
-	t.is(actualVal, expectVal);
+	t.is(actualValue, expectValue);
 	t.truthy(isCalled);
 });

--- a/test.js
+++ b/test.js
@@ -182,3 +182,23 @@ test('checks total cache size does not exceed `maxSize`', t => {
 	lru.get('1');
 	t.is(lru.oldCache.has('1'), false);
 });
+
+test('checks to see if onEviction method is called after `maxSize` is exceeded', t => {
+	let isCalled = false;
+	let actualKey;
+	let actualVal;
+	const expectKey = '1';
+	const expectVal = 1;
+	const onEviction = (key, val) => {
+		actualKey = key;
+		actualVal = val;
+		isCalled = true;
+	};
+
+	const lru = new QuickLRU({maxSize: 1, onEviction});
+	lru.set(expectKey, expectVal);
+	lru.set('2', 2);
+	t.is(actualKey, expectKey);
+	t.is(actualVal, expectVal);
+	t.truthy(isCalled);
+});

--- a/test.js
+++ b/test.js
@@ -201,5 +201,5 @@ test('`onEviction` option method is called after `maxSize` is exceeded', t => {
 	lru.set('2', 2);
 	t.is(actualKey, expectKey);
 	t.is(actualValue, expectValue);
-	t.truthy(isCalled);
+	t.true(isCalled);
 });


### PR DESCRIPTION
This is a neat library, I like how it uses a map rotation implementation.

I thought it would be useful to give the option for a cleanup method when something is about to be evicted from the cache.