### PR TITLE
Ensure TypeScript generics are propagated to options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare namespace QuickLRU {
-	interface Options {
+	interface Options<KeyType, ValueType> {
 		/**
 		The maximum number of items before evicting the least recently used items.
 		*/
@@ -10,7 +10,7 @@ declare namespace QuickLRU {
 
 		Useful for side effects or for items like object URLs that need explicit cleanup (`revokeObjectURL`).
 		*/
-		onEviction?: <KeyType, ValueType>(key: KeyType, value: ValueType) => void;
+		onEviction?: (key: KeyType, value: ValueType) => void;
 	}
 }
 
@@ -41,7 +41,7 @@ declare class QuickLRU<KeyType, ValueType>
 	//=> '🌈'
 	```
 	*/
-	constructor(options: QuickLRU.Options);
+	constructor(options: QuickLRU.Options<KeyType, ValueType>);
 
 	[Symbol.iterator](): IterableIterator<[KeyType, ValueType]>;
 


### PR DESCRIPTION
The types passes to the generic QuickLRU constructor should be passed on to the options too, otherwise things like this will trigger an error:

```ts
new QuickLRU<string, { foo: { bar: true } }> ({ 
  maxSize: 100,
  onEviction: ( key, value ) => {
    value.foo.bar
  }
});
```

I'm not sure how to write a test for this, but I've tested it manually and it seems to work for me.

Before:

![image](https://user-images.githubusercontent.com/1812093/83360337-65f24280-a378-11ea-9d6f-c2035800291e.png)

After:

![image](https://user-images.githubusercontent.com/1812093/83360339-6a1e6000-a378-11ea-9eb6-5f544c2ee7da.png)
