### PR TITLE
Improve performance of `.size`

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,6 +109,10 @@ class QuickLRU {
 	}
 
 	get size() {
+		if (!this._size) {
+			return this.oldCache.size;
+		}
+
 		let oldCacheSize = 0;
 		for (const key of this.oldCache.keys()) {
 			if (!this.cache.has(key)) {

--- a/test.js
+++ b/test.js
@@ -171,6 +171,7 @@ test('max size', t => {
 	lru.set('1', 1);
 	lru.set('2', 2);
 	lru.set('3', 3);
+	t.is(lru.size, 3);
 	lru.set('4', 4);
 	t.is(lru.size, 3);
 });


### PR DESCRIPTION
In the event that we just rotated the caches, and the primary cache is empty, we should be able to just read the size of the old cache.