### PR TITLE
Add `.resize()` method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -84,7 +84,9 @@ declare class QuickLRU<KeyType, ValueType>
 	clear(): void;
 
 	/**
-	Resize the cache to fit the given maximum number of items.
+	Update the `maxSize` in-place, discarding items as necessary. Insertion order is mostly preserved, though this is not a strong guarantee.
+
+	Useful for on-the-fly tuning of cache sizes in live systems.
 	*/
 	resize(maxSize: number): void;
 
@@ -99,12 +101,12 @@ declare class QuickLRU<KeyType, ValueType>
 	values(): IterableIterator<ValueType>;
 
 	/**
-	Iterable for all entries, starting with the least recently used.
+	Iterable for all entries, starting with the oldest (ascending in recency).
 	*/
 	entriesAscending(): IterableIterator<[KeyType, ValueType]>;
 
 	/**
-	Iterable for all entries, starting with the most recently used.
+	Iterable for all entries, starting with the newest (descending in recency).
 	*/
 	entriesDescending(): IterableIterator<[KeyType, ValueType]>;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -92,6 +92,21 @@ declare class QuickLRU<KeyType, ValueType>
 	Iterable for all the values.
 	*/
 	values(): IterableIterator<ValueType>;
+
+	/**
+	Iterable for all entries, starting with the least recently used.
+	*/
+	entriesAscending(): IterableIterator<[KeyType, ValueType]>;
+
+	/**
+	Iterable for all entries, starting with the most recently used.
+	*/
+	entriesDescending(): IterableIterator<[KeyType, ValueType]>;
+
+	/**
+	Resize to fit the given maximum number of items.
+	*/
+	resize(maxSize: number): void;
 }
 
 export = QuickLRU;

--- a/index.d.ts
+++ b/index.d.ts
@@ -84,6 +84,11 @@ declare class QuickLRU<KeyType, ValueType>
 	clear(): void;
 
 	/**
+	Resize the cache to fit the given maximum number of items.
+	*/
+	resize(maxSize: number): void;
+
+	/**
 	Iterable for all the keys.
 	*/
 	keys(): IterableIterator<KeyType>;
@@ -102,11 +107,6 @@ declare class QuickLRU<KeyType, ValueType>
 	Iterable for all entries, starting with the most recently used.
 	*/
 	entriesDescending(): IterableIterator<[KeyType, ValueType]>;
-
-	/**
-	Resize to fit the given maximum number of items.
-	*/
-	resize(maxSize: number): void;
 }
 
 export = QuickLRU;

--- a/index.js
+++ b/index.js
@@ -13,19 +13,23 @@ class QuickLRU {
 		this._size = 0;
 	}
 
+	_emitEvictions(cache) {
+		if (typeof this.onEviction !== 'function') {
+			return;
+		}
+
+		for (const [key, value] of cache) {
+			this.onEviction(key, value);
+		}
+	}
+
 	_set(key, value) {
 		this.cache.set(key, value);
 		this._size++;
 
 		if (this._size >= this.maxSize) {
 			this._size = 0;
-
-			if (typeof this.onEviction === 'function') {
-				for (const [key, value] of this.oldCache.entries()) {
-					this.onEviction(key, value);
-				}
-			}
-
+			this._emitEvictions(this.oldCache);
 			this.oldCache = this.cache;
 			this.cache = new Map();
 		}
@@ -96,9 +100,7 @@ class QuickLRU {
 	}
 
 	* [Symbol.iterator]() {
-		for (const item of this.cache) {
-			yield item;
-		}
+		yield * this.cache;
 
 		for (const item of this.oldCache) {
 			const [key] = item;
@@ -106,6 +108,33 @@ class QuickLRU {
 				yield item;
 			}
 		}
+	}
+
+	* entriesDescending() {
+		let items = [...this.cache];
+		for (let i = items.length - 1; i >= 0; --i) {
+			yield items[i];
+		}
+
+		items = [...this.oldCache];
+		for (let i = items.length - 1; i >= 0; --i) {
+			const item = items[i];
+			const [key] = item;
+			if (!this.cache.has(key)) {
+				yield item;
+			}
+		}
+	}
+
+	* entriesAscending() {
+		for (const item of this.oldCache) {
+			const [key] = item;
+			if (!this.cache.has(key)) {
+				yield item;
+			}
+		}
+
+		yield * this.cache;
 	}
 
 	get size() {
@@ -121,6 +150,30 @@ class QuickLRU {
 		}
 
 		return Math.min(this._size + oldCacheSize, this.maxSize);
+	}
+
+	resize(newSize) {
+		if (!(newSize && newSize > 0)) {
+			throw new TypeError('`maxSize` must be a number greater than 0');
+		}
+
+		const items = [...this.entriesAscending()];
+		const removeCount = items.length - newSize;
+		if (removeCount < 0) {
+			this.cache = new Map(items);
+			this.oldCache = new Map();
+			this._size = items.length;
+		} else {
+			if (removeCount > 0) {
+				this._emitEvictions(items.slice(0, removeCount));
+			}
+
+			this.oldCache = new Map(items.slice(removeCount));
+			this.cache = new Map();
+			this._size = 0;
+		}
+
+		this.maxSize = newSize;
 	}
 }
 

--- a/index.js
+++ b/index.js
@@ -86,6 +86,30 @@ class QuickLRU {
 		this.oldCache.clear();
 		this._size = 0;
 	}
+	
+	resize(newSize) {
+		if (!(newSize && newSize > 0)) {
+			throw new TypeError('`maxSize` must be a number greater than 0');
+		}
+
+		const items = [...this.entriesAscending()];
+		const removeCount = items.length - newSize;
+		if (removeCount < 0) {
+			this.cache = new Map(items);
+			this.oldCache = new Map();
+			this._size = items.length;
+		} else {
+			if (removeCount > 0) {
+				this._emitEvictions(items.slice(0, removeCount));
+			}
+
+			this.oldCache = new Map(items.slice(removeCount));
+			this.cache = new Map();
+			this._size = 0;
+		}
+
+		this.maxSize = newSize;
+	}
 
 	* keys() {
 		for (const [key] of this) {
@@ -150,30 +174,6 @@ class QuickLRU {
 		}
 
 		return Math.min(this._size + oldCacheSize, this.maxSize);
-	}
-
-	resize(newSize) {
-		if (!(newSize && newSize > 0)) {
-			throw new TypeError('`maxSize` must be a number greater than 0');
-		}
-
-		const items = [...this.entriesAscending()];
-		const removeCount = items.length - newSize;
-		if (removeCount < 0) {
-			this.cache = new Map(items);
-			this.oldCache = new Map();
-			this._size = items.length;
-		} else {
-			if (removeCount > 0) {
-				this._emitEvictions(items.slice(0, removeCount));
-			}
-
-			this.oldCache = new Map(items.slice(removeCount));
-			this.cache = new Map();
-			this._size = 0;
-		}
-
-		this.maxSize = newSize;
 	}
 }
 

--- a/readme.md
+++ b/readme.md
@@ -94,9 +94,23 @@ Iterable for all the keys.
 
 Iterable for all the values.
 
+#### .entriesAscending()
+
+Iterable for all entries, starting with the oldest (ascending in recency).
+
+#### .entriesDescending()
+
+Iterable for all entries, starting with the newest (descending in recency).
+
 #### .size
 
 The stored item count.
+
+#### .resize(maxSize)
+
+Update the maxSize of the QuickLRU in-place, discarding items as necessary. Insertion order is mostly preserved, though this is not a strong guarantee.
+
+Useful for on-the-fly tuning of cache sizes in live systems.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,12 @@ Returns `true` if the item is removed or `false` if the item doesn't exist.
 
 Delete all items.
 
+#### .resize(maxSize)
+
+Update the maxSize of the QuickLRU in-place, discarding items as necessary. Insertion order is mostly preserved, though this is not a strong guarantee.
+
+Useful for on-the-fly tuning of cache sizes in live systems.
+
 #### .keys()
 
 Iterable for all the keys.
@@ -105,12 +111,6 @@ Iterable for all entries, starting with the newest (descending in recency).
 #### .size
 
 The stored item count.
-
-#### .resize(maxSize)
-
-Update the maxSize of the QuickLRU in-place, discarding items as necessary. Insertion order is mostly preserved, though this is not a strong guarantee.
-
-Useful for on-the-fly tuning of cache sizes in live systems.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ Delete all items.
 
 #### .resize(maxSize)
 
-Update the maxSize of the QuickLRU in-place, discarding items as necessary. Insertion order is mostly preserved, though this is not a strong guarantee.
+Update the `maxSize`, discarding items as necessary. Insertion order is mostly preserved, though this is not a strong guarantee.
 
 Useful for on-the-fly tuning of cache sizes in live systems.
 

--- a/test.js
+++ b/test.js
@@ -204,3 +204,80 @@ test('`onEviction` option method is called after `maxSize` is exceeded', t => {
 	t.is(actualValue, expectValue);
 	t.true(isCalled);
 });
+
+test('entriesAscending enumerates cache items oldest-first', t => {
+	const lru = new QuickLRU({maxSize: 3});
+	lru.set('1', 1);
+	lru.set('2', 2);
+	lru.set('3', 3);
+	lru.set('3', 7);
+	lru.set('2', 8);
+	t.deepEqual([...lru.entriesAscending()], [['1', 1], ['3', 7], ['2', 8]]);
+});
+
+test('entriesDescending enumerates cache items newest-first', t => {
+	const lru = new QuickLRU({maxSize: 3});
+	lru.set('t', 1);
+	lru.set('q', 2);
+	lru.set('a', 8);
+	lru.set('t', 4);
+	lru.set('v', 3);
+	t.deepEqual([...lru.entriesDescending()], [['v', 3], ['t', 4], ['a', 8], ['q', 2]]);
+});
+
+test('resize removes older items', t => {
+	const lru = new QuickLRU({maxSize: 2});
+	lru.set('1', 1);
+	lru.set('2', 2);
+	lru.set('3', 3);
+	lru.resize(1);
+	t.is(lru.peek('1'), undefined);
+	t.is(lru.peek('3'), 3);
+	lru.set('3', 4);
+	t.is(lru.peek('3'), 4);
+	lru.set('4', 5);
+	t.is(lru.peek('4'), 5);
+	t.is(lru.peek('2'), undefined);
+});
+
+test('resize omits evictions', t => {
+	const calls = [];
+	const onEviction = (...args) => calls.push(args);
+	const lru = new QuickLRU({maxSize: 2, onEviction});
+
+	lru.set('1', 1);
+	lru.set('2', 2);
+	lru.set('3', 3);
+	lru.resize(1);
+	t.true(calls.length >= 1);
+	t.true(calls.some(([key]) => key === '1'));
+});
+
+test('resize increases capacity', t => {
+	const lru = new QuickLRU({maxSize: 2});
+	lru.set('1', 1);
+	lru.set('2', 2);
+	lru.resize(3);
+	lru.set('3', 3);
+	lru.set('4', 4);
+	lru.set('5', 5);
+	t.deepEqual([...lru.entriesAscending()], [['1', 1], ['2', 2], ['3', 3], ['4', 4], ['5', 5]]);
+});
+
+test('resize does not conflict with the same number of items', t => {
+	const lru = new QuickLRU({maxSize: 2});
+	lru.set('1', 1);
+	lru.set('2', 2);
+	lru.set('3', 3);
+	lru.resize(3);
+	lru.set('4', 4);
+	lru.set('5', 5);
+	t.deepEqual([...lru.entriesAscending()], [['1', 1], ['2', 2], ['3', 3], ['4', 4], ['5', 5]]);
+});
+
+test('resize checks parameter bounds', t => {
+	const lru = new QuickLRU({maxSize: 2});
+	t.throws(() => {
+		lru.resize(-1);
+	}, /maxSize/);
+});


### PR DESCRIPTION
This allows dynamic resizing of the QuickLRU instance, while mostly preserving insertion order and thus remaining reasonably faithful to the most recent items. The exception is when items are updated - they aren't reorder to be at the front of the `Map`.

Two implementation considerations:

- We might want to update the Map order when values are updated, though that'll impact performance. Opt-in might be an option, but unless there's clear interest in that functionality it's probably not worth addressing.
- We might want to track the actual number of items represented by the LRU (i.e. the ones that haven't been evicted, deduplicating between the two Maps). This would also impose a runtime penalty for insertions (and sometimes updates), but would simplify and optimize the `resize` code. I'm running under the assumption that `resize` operations will be rare, and are thus not worth optimizing much more than they already are (they might be overoptimized already).

If this feature and its limitation are things you're willing to support, I can add tests and documentation. If not, supporting at least `entriesAscending` and `entriesDescending` (name isn't great but is intended to be relative to insertion order) would allow this feature to be implemented externally.

Addresses #19.