### PR TITLE
Make `QuickLRU` a `Map` subclass

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,7 @@ export interface Options<KeyType, ValueType> {
 	onEviction?: (key: KeyType, value: ValueType) => void;
 }
 
-export default class QuickLRU<KeyType, ValueType> implements Iterable<[KeyType, ValueType]> {
+export default class QuickLRU<KeyType, ValueType> extends Map implements Iterable<[KeyType, ValueType]> {
 	/**
 	The stored item count.
 	*/

--- a/index.js
+++ b/index.js
@@ -269,9 +269,9 @@ export default class QuickLRU extends Map {
 		return this.entriesAscending();
 	}
 
-	forEach(fn, thisArg = this) {
+	forEach(callbackFunction, thisArgument = this) {
 		for (const [key, value] of this._entriesAscending()) {
-			fn.call(thisArg, value.value, key, this);
+			callbackFunction.call(thisArgument, value.value, key, this);
 		}
 	}
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
-export default class QuickLRU {
+export default class QuickLRU extends Map {
 	constructor(options = {}) {
+		super();
 		if (!(options.maxSize && options.maxSize > 0)) {
 			throw new TypeError('`maxSize` must be a number greater than 0');
 		}
@@ -261,5 +262,21 @@ export default class QuickLRU {
 		}
 
 		return Math.min(this._size + oldCacheSize, this.maxSize);
+	}
+
+	* entries() {
+		for (const [key, value] of this._entriesAscending()) {
+			yield [key, value.value];
+		}
+	}
+
+	forEach(fn, thisArg = this) {
+		for (const [key, value] of this._entriesAscending()) {
+			fn.call(thisArg, value.value, key, this);
+		}
+	}
+
+	[Symbol.toStringTag]() {
+		return JSON.stringify([...this.cache, ...this.oldCache]);
 	}
 }

--- a/index.js
+++ b/index.js
@@ -270,8 +270,8 @@ export default class QuickLRU extends Map {
 	}
 
 	forEach(callbackFunction, thisArgument = this) {
-		for (const [key, value] of this._entriesAscending()) {
-			callbackFunction.call(thisArgument, value.value, key, this);
+		for (const [key, value] of this.entriesAscending()) {
+			callbackFunction.call(thisArgument, value, key, this);
 		}
 	}
 

--- a/index.js
+++ b/index.js
@@ -264,10 +264,8 @@ export default class QuickLRU extends Map {
 		return Math.min(this._size + oldCacheSize, this.maxSize);
 	}
 
-	* entries() {
-		for (const [key, value] of this._entriesAscending()) {
-			yield [key, value.value];
-		}
+	entries() {
+		return this.entriesAscending();
 	}
 
 	forEach(fn, thisArg = this) {
@@ -277,6 +275,6 @@ export default class QuickLRU extends Map {
 	}
 
 	[Symbol.toStringTag]() {
-		return JSON.stringify([...this.cache, ...this.oldCache]);
+		return JSON.stringify([...this.entriesAscending()]);
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ lru.get('🦄');
 
 ### new QuickLRU(options?)
 
-Returns a new instance.
+Returns a new instance extending from [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map).
 
 ### options
 
@@ -124,11 +124,11 @@ Iterable for all entries, starting with the newest (descending in recency).
 
 #### .entries()
 
-Iterable for all entries, starting with the newest (ascending in recency). We encourage not to use this method unless you need Map compatibility. Use [.entriesAscending()](#.entriesAscending()) instead.
+Iterable for all entries, starting with the newest (ascending in recency). We encourage not to use this method unless you need Map compatibility. Use [.entriesAscending()](#entriesascending) instead.
 
 #### .forEach(callbackFn, thisArgs)
 
-Loop over entries calling the callbackFn for each entry (ascending in recency). We encourage not to use this method unless you need Map compatibility. Use [.entriesAscending()](#.entriesAscending()) instead.
+Loop over entries calling the callbackFn for each entry (ascending in recency). We encourage not to use this method unless you need Map compatibility. Use [.entriesAscending()](#entriesascending) instead.
 
 #### .size
 

--- a/readme.md
+++ b/readme.md
@@ -122,6 +122,14 @@ Iterable for all entries, starting with the oldest (ascending in recency).
 
 Iterable for all entries, starting with the newest (descending in recency).
 
+#### .entries()
+
+Iterable for all entries, starting with the newest (ascending in recency). We encourage not to use this method unless you need Map compatibility. Use [.entriesAscending()](#.entriesAscending()) instead.
+
+#### .forEach(callbackFn, thisArgs)
+
+Loop over entries calling the callbackFn for each entry (ascending in recency). We encourage not to use this method unless you need Map compatibility. Use [.entriesAscending()](#.entriesAscending()) instead.
+
 #### .size
 
 The stored item count.

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,9 @@ lru.get('🦄');
 
 ### new QuickLRU(options?)
 
-Returns a new instance extending from [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map).
+Returns a new instance.
+
+It's a [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) subclass.
 
 ### options
 

--- a/test.js
+++ b/test.js
@@ -577,30 +577,6 @@ test('max age - `entriesAscending()` should return the entries that are not expi
 	t.deepEqual([...lru.entriesAscending()], [['3', 'test3'], ['4', 'coco'], ['5', 'loco']]);
 });
 
-test('max age - `entries()` should not return expired entries', async t => {
-	const lru = new QuickLRU({maxSize: 5, maxAge: 100});
-	lru.set('1', undefined);
-	lru.set('2', 'test2');
-	lru.set('3', 'test3');
-	await delay(200);
-	lru.set('4', 'coco');
-	lru.set('5', 'loco');
-
-	t.deepEqual([...lru.entries()], [['4', 'coco'], ['5', 'loco']]);
-});
-
-test('max age - `entries() should not return expired entries even if are not recent', async t => {
-	const lru = new QuickLRU({maxSize: 3, maxAge: 100});
-	lru.set('1', undefined);
-	lru.set('2', 'test2');
-	lru.set('3', 'test3');
-	await delay(200);
-	lru.set('4', 'coco');
-	lru.set('5', 'loco');
-
-	t.deepEqual([...lru.entries()], [['4', 'coco'], ['5', 'loco']]);
-});
-
 test('max age - `entries()` should return the entries that are not expired', async t => {
 	const lru = new QuickLRU({maxSize: 10, maxAge: 100});
 	lru.set('1', undefined);

--- a/test.js
+++ b/test.js
@@ -630,42 +630,6 @@ test('max age - `forEach()` should not return expired entries', async t => {
 	t.deepEqual(entries, [['4', 'coco'], ['5', 'loco']]);
 });
 
-test('max age - `forEach() should not return expired entries even if are not recent', async t => {
-	const lru = new QuickLRU({maxSize: 3, maxAge: 100});
-	lru.set('1', undefined);
-	lru.set('2', 'test2');
-	lru.set('3', 'test3');
-	await delay(200);
-	lru.set('4', 'coco');
-	lru.set('5', 'loco');
-
-	const entries = [];
-
-	lru.forEach((value, key) => {
-		entries.push([key, value]);
-	});
-
-	t.deepEqual(entries, [['4', 'coco'], ['5', 'loco']]);
-});
-
-test('max age - `forEach()` should return the entries that are not expired', async t => {
-	const lru = new QuickLRU({maxSize: 10, maxAge: 100});
-	lru.set('1', undefined);
-	lru.set('2', 'test2');
-	await delay(200);
-	lru.set('3', 'test3');
-	lru.set('4', 'coco');
-	lru.set('5', 'loco');
-
-	const entries = [];
-
-	lru.forEach((value, key) => {
-		entries.push([key, value]);
-	});
-
-	t.deepEqual(entries, [['3', 'test3'], ['4', 'coco'], ['5', 'loco']]);
-});
-
 test('max age - `.[Symbol.iterator]()` should not return expired items', async t => {
 	const lru = new QuickLRU({maxSize: 2, maxAge: 100});
 	lru.set('key', 'value');
@@ -801,9 +765,9 @@ test('function value', t => {
 	t.true(isCalled);
 });
 
-test('toString convert the cache items to string in ascending order', t => {
+test('[Symbol.toStringTag] convert the cache items to string in ascending order', t => {
 	const lru = new QuickLRU({maxSize: 2});
 	lru.set('1', 1);
 	lru.set('2', 2);
-	t.is(lru[Symbol.toStringTag](), '[["1",{"value":1}],["2",{"value":2}]]');
+	t.is(lru[Symbol.toStringTag](), '[["1",1],["2",2]]');
 });

--- a/test.js
+++ b/test.js
@@ -577,6 +577,95 @@ test('max age - `entriesAscending()` should return the entries that are not expi
 	t.deepEqual([...lru.entriesAscending()], [['3', 'test3'], ['4', 'coco'], ['5', 'loco']]);
 });
 
+test('max age - `entries()` should not return expired entries', async t => {
+	const lru = new QuickLRU({maxSize: 5, maxAge: 100});
+	lru.set('1', undefined);
+	lru.set('2', 'test2');
+	lru.set('3', 'test3');
+	await delay(200);
+	lru.set('4', 'coco');
+	lru.set('5', 'loco');
+
+	t.deepEqual([...lru.entries()], [['4', 'coco'], ['5', 'loco']]);
+});
+
+test('max age - `entries() should not return expired entries even if are not recent', async t => {
+	const lru = new QuickLRU({maxSize: 3, maxAge: 100});
+	lru.set('1', undefined);
+	lru.set('2', 'test2');
+	lru.set('3', 'test3');
+	await delay(200);
+	lru.set('4', 'coco');
+	lru.set('5', 'loco');
+
+	t.deepEqual([...lru.entries()], [['4', 'coco'], ['5', 'loco']]);
+});
+
+test('max age - `entries()` should return the entries that are not expired', async t => {
+	const lru = new QuickLRU({maxSize: 10, maxAge: 100});
+	lru.set('1', undefined);
+	lru.set('2', 'test2');
+	await delay(200);
+	lru.set('3', 'test3');
+	lru.set('4', 'coco');
+	lru.set('5', 'loco');
+
+	t.deepEqual([...lru.entries()], [['3', 'test3'], ['4', 'coco'], ['5', 'loco']]);
+});
+
+test('max age - `forEach()` should not return expired entries', async t => {
+	const lru = new QuickLRU({maxSize: 5, maxAge: 100});
+	lru.set('1', undefined);
+	lru.set('2', 'test2');
+	lru.set('3', 'test3');
+	await delay(200);
+	lru.set('4', 'coco');
+	lru.set('5', 'loco');
+	const entries = [];
+
+	lru.forEach((value, key) => {
+		entries.push([key, value]);
+	});
+
+	t.deepEqual(entries, [['4', 'coco'], ['5', 'loco']]);
+});
+
+test('max age - `forEach() should not return expired entries even if are not recent', async t => {
+	const lru = new QuickLRU({maxSize: 3, maxAge: 100});
+	lru.set('1', undefined);
+	lru.set('2', 'test2');
+	lru.set('3', 'test3');
+	await delay(200);
+	lru.set('4', 'coco');
+	lru.set('5', 'loco');
+
+	const entries = [];
+
+	lru.forEach((value, key) => {
+		entries.push([key, value]);
+	});
+
+	t.deepEqual(entries, [['4', 'coco'], ['5', 'loco']]);
+});
+
+test('max age - `forEach()` should return the entries that are not expired', async t => {
+	const lru = new QuickLRU({maxSize: 10, maxAge: 100});
+	lru.set('1', undefined);
+	lru.set('2', 'test2');
+	await delay(200);
+	lru.set('3', 'test3');
+	lru.set('4', 'coco');
+	lru.set('5', 'loco');
+
+	const entries = [];
+
+	lru.forEach((value, key) => {
+		entries.push([key, value]);
+	});
+
+	t.deepEqual(entries, [['3', 'test3'], ['4', 'coco'], ['5', 'loco']]);
+});
+
 test('max age - `.[Symbol.iterator]()` should not return expired items', async t => {
 	const lru = new QuickLRU({maxSize: 2, maxAge: 100});
 	lru.set('key', 'value');
@@ -615,6 +704,32 @@ test('entriesDescending enumerates cache items newest-first', t => {
 	lru.set('t', 4);
 	lru.set('v', 3);
 	t.deepEqual([...lru.entriesDescending()], [['v', 3], ['t', 4], ['a', 8], ['q', 2]]);
+});
+
+test('entries enumerates cache items oldest-first', t => {
+	const lru = new QuickLRU({maxSize: 3});
+	lru.set('1', 1);
+	lru.set('2', 2);
+	lru.set('3', 3);
+	lru.set('3', 7);
+	lru.set('2', 8);
+	t.deepEqual([...lru.entries()], [['1', 1], ['3', 7], ['2', 8]]);
+});
+
+test('forEach calls the cb function for each cache item oldest-first', t => {
+	const lru = new QuickLRU({maxSize: 3});
+	lru.set('1', 1);
+	lru.set('2', 2);
+	lru.set('3', 3);
+	lru.set('3', 7);
+	lru.set('2', 8);
+	const entries = [];
+
+	lru.forEach((value, key) => {
+		entries.push([key, value]);
+	});
+
+	t.deepEqual(entries, [['1', 1], ['3', 7], ['2', 8]]);
 });
 
 test('resize removes older items', t => {
@@ -684,4 +799,11 @@ test('function value', t => {
 
 	lru.get('fn')();
 	t.true(isCalled);
+});
+
+test('toString convert the cache items to string in ascending order', t => {
+	const lru = new QuickLRU({maxSize: 2});
+	lru.set('1', 1);
+	lru.set('2', 2);
+	t.is(lru[Symbol.toStringTag](), '[["1",{"value":1}],["2",{"value":2}]]');
 });


### PR DESCRIPTION
Make QuickLRU compatible with MAP signature by implementing the missing methods

Closes #34 