### PR TITLE
Added method to expose remaining ttl of given cache entry.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -79,13 +79,13 @@ export default class QuickLRU<KeyType, ValueType> extends Map<KeyType, ValueType
 	peek(key: KeyType): ValueType | undefined;
 
 	/**
-	Get the remaining time to live for an item, or undefined for item not in cache.
+	Get the remaining time to live in ms for given item, or undefined when item is not in cache.
 	Does not mark it as recently used.
 	Does not remove entry from cache when item is expired.
 
 	@returns Remaining time to live in ms when set, or infinity when maxAge is not set. Undefined when item does not exist.
 	*/
-	ttl(key: KeyType): number | undefined;
+	expiresIn(key: KeyType): number | undefined;
 
 	/**
 	Delete an item.

--- a/index.d.ts
+++ b/index.d.ts
@@ -79,6 +79,15 @@ export default class QuickLRU<KeyType, ValueType> extends Map<KeyType, ValueType
 	peek(key: KeyType): ValueType | undefined;
 
 	/**
+	Get the remaining time to live for an item, or undefined for item not in cache.
+	Does not mark it as recently used.
+	Does not remove entry from cache when item is expired.
+
+	@returns Remaining time to live in ms when set, or infinity when maxAge is not set. Undefined when item does not exist.
+	*/
+	ttl(key: KeyType): number | undefined;
+
+	/**
 	Delete an item.
 
 	@returns `true` if the item is removed or `false` if the item doesn't exist.

--- a/index.js
+++ b/index.js
@@ -156,7 +156,7 @@ export default class QuickLRU extends Map {
 		}
 	}
 
-	ttl(key) {
+	expiresIn(key) {
 		const item = this.#cache.get(key) ?? this.#oldCache.get(key);
 		if (item) {
 			return item.expiry ? item.expiry - Date.now() : Number.POSITIVE_INFINITY;

--- a/index.js
+++ b/index.js
@@ -62,7 +62,6 @@ export default class QuickLRU extends Map {
 
 	#peek(key, cache) {
 		const item = cache.get(key);
-
 		return this.#getItemValue(key, item);
 	}
 
@@ -154,6 +153,13 @@ export default class QuickLRU extends Map {
 
 		if (this.#oldCache.has(key)) {
 			return this.#peek(key, this.#oldCache);
+		}
+	}
+
+	ttl(key) {
+		const item = this.#cache.get(key) ?? this.#oldCache.get(key);
+		if (item) {
+			return item.expiry ? item.expiry - Date.now() : Number.POSITIVE_INFINITY;
 		}
 	}
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -7,6 +7,7 @@ expectType<QuickLRU<string, number>>(lru.set('🦄', 1).set('🌈', 2));
 expectType<number | undefined>(lru.get('🦄'));
 expectType<boolean>(lru.has('🦄'));
 expectType<number | undefined>(lru.peek('🦄'));
+expectType<number | undefined>(lru.expiresIn('🦄'));
 expectType<boolean>(lru.delete('🦄'));
 expectType<number>(lru.size);
 

--- a/readme.md
+++ b/readme.md
@@ -92,6 +92,12 @@ Check if an item exists.
 
 Get an item without marking it as recently used.
 
+#### .expiresIn(key)
+
+Get the remaining time to live in ms for given item, or undefined when item is not in cache.
+Does not mark it as recently used. 
+Does not remove entry from cache when item is expired.
+
 #### .delete(key)
 
 Delete an item.

--- a/test.js
+++ b/test.js
@@ -87,6 +87,26 @@ test('.peek()', t => {
 	t.false(lru.has('1'));
 });
 
+test('.ttl() - non-existing key yields undefined', t => {
+	const lru = new QuickLRU({maxSize: 100});
+	t.is(lru.ttl('nope'), undefined);
+});
+
+test('.ttl() - existing key without ttl', t => {
+	const lru = new QuickLRU({maxSize: 100});
+	lru.set('infinity', 'no ttl given');
+	t.is(lru.ttl('infinity'), Number.POSITIVE_INFINITY);
+});
+
+test('.ttl() - existing key with ttl', async t => {
+	const lru = new QuickLRU({maxSize: 100});
+	lru.set('100ms', 'ttl given', {maxAge: 100});
+	t.is(lru.ttl('100ms'), 100);
+	await delay(50);
+	const ttl = lru.ttl('100ms');
+	t.true(ttl > 40 && ttl < 60);
+});
+
 test('.delete()', t => {
 	const lru = new QuickLRU({maxSize: 100});
 	lru.set('foo', 1);

--- a/test.js
+++ b/test.js
@@ -87,23 +87,23 @@ test('.peek()', t => {
 	t.false(lru.has('1'));
 });
 
-test('.ttl() - non-existing key yields undefined', t => {
+test('.expiresIn() - non-existing key yields undefined', t => {
 	const lru = new QuickLRU({maxSize: 100});
-	t.is(lru.ttl('nope'), undefined);
+	t.is(lru.expiresIn('nope'), undefined);
 });
 
-test('.ttl() - existing key without ttl', t => {
+test('.expiresIn() - existing key without ttl', t => {
 	const lru = new QuickLRU({maxSize: 100});
 	lru.set('infinity', 'no ttl given');
-	t.is(lru.ttl('infinity'), Number.POSITIVE_INFINITY);
+	t.is(lru.expiresIn('infinity'), Number.POSITIVE_INFINITY);
 });
 
-test('.ttl() - existing key with ttl', async t => {
+test('.expiresIn() - existing key with ttl', async t => {
 	const lru = new QuickLRU({maxSize: 100});
 	lru.set('100ms', 'ttl given', {maxAge: 100});
-	t.is(lru.ttl('100ms'), 100);
+	t.is(lru.expiresIn('100ms'), 100);
 	await delay(50);
-	const ttl = lru.ttl('100ms');
+	const ttl = lru.expiresIn('100ms');
 	t.true(ttl > 40 && ttl < 60);
 });
 


### PR DESCRIPTION
Hi,

I'm adding a cache to my application, and need the stored remaining TTL of the stored entry to be able to support _stale while revalidate_.

I've added a `ttl(key)` method to expose the TTL in ms (compliant with the maxAge option), and added tests.

Thanks!